### PR TITLE
Update List_Bom_Components_Of_BVR.sql

### DIFF
--- a/List_Bom_Components_Of_BVR.sql
+++ b/List_Bom_Components_Of_BVR.sql
@@ -4,5 +4,8 @@ select distinct wso.pobject_name as RootBVR, child.pitem_id as Occurrence Child 
 from ppsoccurrence occ
 join ppsbomviewrevision bvr on bvr.puid = occ.rparent_bvru
 join pworkspaceobject wso on wso.puid = bvr.puid
+join pstructure_revisions revtobvr on revtobvr.pvalu_0 = bvr.puid
+join pitemrevision parentrev on parentrev.puid=revtobvr.puid
+join pitem parentitem on parentitem.puid=parentrev.ritems_tagu
 left join pitem child on child.puid = occ.rchild_itemu
-where wso.pobject_name like '<item-id>/AA-View'
+where parentitem.pitem_id='<item-id>' AND parentrev.pitem_revision_id='AA';


### PR DESCRIPTION
My suggestion is to use specific Item name and Revision code instead of the "freetext" BVR name, which can be spelled differently in various localizations of Teamcenter (e.g. German localization would have '<item.id>/AA-Ansicht'